### PR TITLE
Register AOP 추가

### DIFF
--- a/src/main/java/io/grz/cocktail/config/oauth/PrincipalOAuth2UserService.java
+++ b/src/main/java/io/grz/cocktail/config/oauth/PrincipalOAuth2UserService.java
@@ -48,7 +48,7 @@ public class PrincipalOAuth2UserService extends DefaultOAuth2UserService {
             userEntity.setUsername(oAuth2UserInfo.getEmail());
             userEntity.setPassword(bCryptPasswordEncoder.encode(UUID.randomUUID().toString()));
             userEntity.setNickname(oAuth2UserInfo.getProvider()+"_"+oAuth2UserInfo.getProviderId());
-            userEntity.setRole("ROLE_USER");
+            userEntity.setRole("USER");
             userEntity.setProvider(oAuth2UserInfo.getProvider());
             userEntity.setProviderId(oAuth2UserInfo.getProviderId());
             System.out.println(userEntity);

--- a/src/main/java/io/grz/cocktail/controller/api/RegisterController.java
+++ b/src/main/java/io/grz/cocktail/controller/api/RegisterController.java
@@ -1,15 +1,19 @@
 package io.grz.cocktail.controller.api;
 
+import io.grz.cocktail.dto.UserAuthDTO;
 import io.grz.cocktail.model.user.User;
 import io.grz.cocktail.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.*;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
 
-import java.net.URI;
-import java.net.URISyntaxException;
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.Valid;
 
 @RestController
 @RequiredArgsConstructor
@@ -18,11 +22,13 @@ public class RegisterController {
     private final UserService userService;
 
     @PostMapping("/api/register")
-    public ResponseEntity<String> register(@RequestBody User user){
-        if(user.getPassword()==null) return new ResponseEntity<>("올바르지 않은 비밀번호입니다.", HttpStatus.INTERNAL_SERVER_ERROR);
-        boolean result = userService.isUsernameUnique(user.getUsername());
-        if (!result) return new ResponseEntity<>("이미 사용중인 이메일입니다.", HttpStatus.INTERNAL_SERVER_ERROR);
-        userService.register(user);
+    public ResponseEntity<?> register(@Valid @RequestBody UserAuthDTO dto, BindingResult bindingResult){
+        User user = userService.findByUsername(dto.getUsername());
+        if (user!=null) return new ResponseEntity<>("이미 사용중인 이메일입니다.", HttpStatus.BAD_REQUEST);
+
+        userService.register(dto);
+
         return new ResponseEntity<>("OK", HttpStatus.OK);
     }
+
 }

--- a/src/main/java/io/grz/cocktail/controller/api/advice/UserBindingAdvice.java
+++ b/src/main/java/io/grz/cocktail/controller/api/advice/UserBindingAdvice.java
@@ -1,0 +1,46 @@
+package io.grz.cocktail.controller.api.advice;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+@Slf4j
+@Component
+@Aspect
+public class UserBindingAdvice {
+
+
+    @Around("execution(* io.grz.cocktail.controller.api..*Controller.*(..))")
+    public Object validCheck(ProceedingJoinPoint proceedingJoinPoint) throws Throwable {
+        Object[] args = proceedingJoinPoint.getArgs();
+        String type = proceedingJoinPoint.getSignature().getDeclaringTypeName();
+        String method = proceedingJoinPoint.getSignature().getName();
+
+        for(Object arg : args){
+            if(arg instanceof BindingResult){
+                BindingResult bindingResult = (BindingResult) arg;
+                if(bindingResult.hasErrors()){
+                    Map<String, String> errorMap = new HashMap<>();
+                    for(FieldError error:bindingResult.getFieldErrors()){
+                        errorMap.put(error.getField(), error.getDefaultMessage());
+                        log.warn(type+"."+method+"() => Field: "+error.getField()+", message: "+error.getDefaultMessage());
+                    }
+                    return new ResponseEntity<>(errorMap, HttpStatus.BAD_REQUEST);
+                }
+            }
+        }
+        return proceedingJoinPoint.proceed();
+    }
+}

--- a/src/main/java/io/grz/cocktail/dto/UserAuthDTO.java
+++ b/src/main/java/io/grz/cocktail/dto/UserAuthDTO.java
@@ -1,0 +1,37 @@
+package io.grz.cocktail.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import java.sql.Timestamp;
+
+@Data
+@Builder
+@AllArgsConstructor
+@RequiredArgsConstructor
+public class UserAuthDTO {
+
+    @NotBlank(message = "이메일을 작성해주세요")
+    @Size(max = 50, message = "이메일 길이를 초과하였습니다")
+    private String username;
+
+    @NotBlank(message = "비밀번호를 확인해주세요")
+    @Size(max=75, message = "비밀번호 길이를 초과하였습니다")
+    private String password;
+
+    @NotNull(message = "no key named nickname")
+    @NotBlank(message = "닉네임을 작성해주세요")
+    @Size(max = 50, message = "닉네임 길이를 초과하였습니다")
+    private String nickname;
+    private String role;
+    private String provider;
+    private String providerId;
+    private Timestamp createDate;
+    private Timestamp accessDate;
+
+}

--- a/src/main/java/io/grz/cocktail/model/user/User.java
+++ b/src/main/java/io/grz/cocktail/model/user/User.java
@@ -13,6 +13,9 @@ import lombok.RequiredArgsConstructor;
 import org.hibernate.annotations.CreationTimestamp;
 
 import javax.persistence.*;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
@@ -26,7 +29,7 @@ public class User {
     @Column(name = "USER_ID")
     private long id;
 
-    @Column(nullable = false, unique = true, length=50)
+    @Column(unique = true, length=50)
     private String username;
 
     @Column(nullable = false, length=75)

--- a/src/main/java/io/grz/cocktail/service/UserService.java
+++ b/src/main/java/io/grz/cocktail/service/UserService.java
@@ -1,6 +1,7 @@
 package io.grz.cocktail.service;
 
 import io.grz.cocktail.config.auth.PrincipalDetails;
+import io.grz.cocktail.dto.UserAuthDTO;
 import io.grz.cocktail.dto.UserDTO;
 import io.grz.cocktail.model.user.User;
 import io.grz.cocktail.repository.UserRepository;
@@ -20,20 +21,19 @@ public class UserService {
     private final BCryptPasswordEncoder bCryptPasswordEncoder;
 
     @Transactional
-    public boolean isUsernameUnique(String username){
-            User user = userRepository.findByUsername(username);
-            if(user == null){
-                return true;
-            } else {
-                return false;
-            }
+    public User findByUsername(String username){
+            return userRepository.findByUsername(username);
     }
 
     @Transactional
-    public void register(User user){
-        user.setPassword(bCryptPasswordEncoder.encode(user.getPassword()));
+    public void register(UserAuthDTO dto){
+        User user = new User();
+        user.setUsername(dto.getUsername());
+        user.setPassword(bCryptPasswordEncoder.encode(dto.getPassword()));
         user.setRole("USER");
+        user.setNickname(dto.getNickname());
         userRepository.save(user);
+        
     }
 
     @Transactional

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -34,3 +34,38 @@ spring:
   devtools:
     livereload:
       enabled: true
+
+  security:
+    oauth2:
+      client:
+        registration:
+          google: # URI: http://localhost:8000/login/oauth2/code/google
+            client-id: 572162728474-nspp4b16qslhvpar00p2ha6ht0n1glsn.apps.googleusercontent.com
+            client-secret: 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
+            scope:
+              - email
+              - profile
+
+          facebook: # URI: http://localhost:8000/login/oauth2/code/google
+            client-id: 1006333013593364
+            client-secret: 93a79df2cb54702bb68a41bb50ff299f
+            scope:
+              - email
+              - public_profile
+
+          naver:
+            client-id: 3fTJQPADGjSsiuLWoa8w
+            client-secret: M0VniWsNj9
+            scope:
+              - name
+              - email
+            client-name: Naver
+            authorization-grant-type: authorization_code
+            redirect-uri: http://localhost:8000/login/oauth2/code/naver
+
+        provider:
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response

--- a/src/main/resources/static/js/register.js
+++ b/src/main/resources/static/js/register.js
@@ -23,11 +23,6 @@ let index = {
             data : JSON.stringify(data),  // http body 데이터
             contentType : "application/json; charset=utf-8", // body 데이터가 어떤 타입인지
         }).done(function(response){
-            console.log(response)
-            if(response.status == 500){
-                alert("something went wrong");
-                return;
-            }
             if(response == "OK"){
                 alert("회원가입이 완료되었습니다.");
                 location.href = "/";
@@ -35,6 +30,10 @@ let index = {
         }).fail(function(error){
             if(error.status == 500){
                 alert(error.responseText);
+            }
+            if(error.status == 400){
+                alert(Object.values(error.responseJSON)[0]);
+                return;
             }
         });
     }


### PR DESCRIPTION
## PR template

### Motivation
회원가입 시 서버단에서의 유저네임, 비밀번호, 이메일의 validity checking을 위해 api/RegisterController에 대한 Advice 구현

### Key changes
UserBindingAdvice 추가 - i.g.c.controller.api 내의 Controller 내 모든 메소드에 대한 커버리지 => 필요에 따라 변경 예정
UserBindingAdvice은 회원가입 시 유저네임, 비밀번호, 닉네임 체킹 공통기능을 대변
Request로부터 api/RegisterController의 Paramater를 받아오는 UserAuthDTO 추가, Model과 Controller의 결함도를 낮추기 위함
UserAuthDTO의 username, password, nickname 멤버에 Validation checking을 위해 어노테이션 추가
api/RegisterController가 받아오는 Paramater에  Valid 어노테이션 추가
register.js 오류 메시지 alert 기능 수정(Response.body를 통해 메시지 출력)

### Done before PR
브라우저 상 동작 테스트 완료

### Tips for reviewer
테스트 함수 구현 예정

### Screenshots

