### PR TITLE
로그인 failure handler 개선

### DIFF
--- a/src/main/java/io/grz/cocktail/config/SecurityConfig.java
+++ b/src/main/java/io/grz/cocktail/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package io.grz.cocktail.config;
 
 import io.grz.cocktail.config.filter.DebugFilter;
 import io.grz.cocktail.config.oauth.PrincipalOAuth2UserService;
+import io.grz.cocktail.handler.LoginFailureHandler;
 import io.grz.cocktail.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
@@ -18,6 +19,7 @@ import org.springframework.web.filter.CorsFilter;
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     private final PrincipalOAuth2UserService principalOAuth2UserService;
+
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
@@ -41,6 +43,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                         .loginPage("/login")
                         .loginProcessingUrl("/login/authenticate")
                         .defaultSuccessUrl("/")
+                        .failureUrl("/login")
+                        .failureHandler(new LoginFailureHandler())
                 .and()
                     .logout()
                         .logoutSuccessUrl("/")

--- a/src/main/java/io/grz/cocktail/config/auth/PrincipalDetailsService.java
+++ b/src/main/java/io/grz/cocktail/config/auth/PrincipalDetailsService.java
@@ -3,11 +3,13 @@ package io.grz.cocktail.config.auth;
 import io.grz.cocktail.model.user.User;
 import io.grz.cocktail.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PrincipalDetailsService implements UserDetailsService {
@@ -16,7 +18,10 @@ public class PrincipalDetailsService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        log.info("Login attempt: username="+username);
         User user = userRepository.findByUsername(username);
+        if(user==null) throw new UsernameNotFoundException("user not found : username="+username);
         return new PrincipalDetails(user);
     }
+
 }

--- a/src/main/java/io/grz/cocktail/handler/LoginFailureHandler.java
+++ b/src/main/java/io/grz/cocktail/handler/LoginFailureHandler.java
@@ -1,0 +1,33 @@
+package io.grz.cocktail.handler;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.InternalAuthenticationServiceException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.URLEncoder;
+
+@Slf4j
+public class LoginFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        String msg="";
+        if(exception instanceof BadCredentialsException || exception instanceof InternalAuthenticationServiceException){
+            msg = "아이디 혹은 비밀번호가 맞지 않습니다.";
+        } else if(exception instanceof UsernameNotFoundException){
+            msg = "사용자가 존재하지 않습니다. 이메일을 확인해주세요";
+        } else msg = "Unknown Exception";
+        log.warn(exception.getClass()+" : "+msg);
+        msg= URLEncoder.encode(msg,"UTF-8");
+        setDefaultFailureUrl("/login?error=true&exception="+msg);
+        super.onAuthenticationFailure(request, response, exception);
+    }
+}

--- a/src/main/java/io/grz/cocktail/service/UserService.java
+++ b/src/main/java/io/grz/cocktail/service/UserService.java
@@ -37,7 +37,6 @@ public class UserService {
 
     @Transactional
     public UserDTO getUserDTOFromPrincipalName(String username){
-        System.out.println(username);
         if(Objects.equals(username, "anonymousUser")) return null;
         User user = userRepository.findByUsername(username);
         if(user == null) return null;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -25,7 +25,7 @@ spring:
       use-new-id-generator-mappings: false
     show-sql: true
     properties:
-      hibernate.format_sql: true
+      hibernate.format_sql: false
 
   jackson:
     serialization:


### PR DESCRIPTION
## PR template

### Motivation
로그인 failure handler 개선

### Key changes
-로그인 실패 시 internal error 사항 수정
-query string으로 에러 메시지 전달, 차후 구현 예정
-PrincipalDetailsService의 user가 null일 때 Exception 처리 로직 추가
-SecurityConfig 내 LoginFailureHandler 추가

### Done before PR


### Tips for reviewer


### Screenshots

